### PR TITLE
Preventing Runtime Error caused by "Event loop is closed"

### DIFF
--- a/tests/test_coo.py
+++ b/tests/test_coo.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -144,6 +145,7 @@ def test_schedule_time_zone_media(coo_preview_instance):
         (0, None, "update"),
         (0, None, "update", "../coo.png"),
     ]
+    coo_preview_instance.loop = asyncio.new_event_loop()
     coo_preview_instance.schedule(updates, time_zone="Canada/Yukon", media="../coo.png")
     assert coo_preview_instance.time_zone == "Canada/Yukon"
     assert coo_preview_instance.media == Path("../coo.png")


### PR DESCRIPTION
This PR aims to improve test reliability by initializing `coo_preview_instance.loop` before executing `asyncio.run_until_complete` by calling method `asyncio.new_event_loop` in order to prevent Runtime Error caused by "Event loop is closed".

The test can fail in the following way if `coo_preview_instance.loop` is not initialized:
```
>       coo_preview_instance.schedule(updates, time_zone="Canada/Yukon", media="../coo.png")

tests/test_coo.py:149: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
coo/coo.py:228: in schedule
    self.loop.run_until_complete(self._async_tasks(updates))
/usr/lib/python3.8/asyncio/base_events.py:591: in run_until_complete
    self._check_closed()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_UnixSelectorEventLoop running=False closed=True debug=False>

    def _check_closed(self):
        if self._closed:
>           raise RuntimeError('Event loop is closed')
E           RuntimeError: Event loop is closed
```